### PR TITLE
Add an Unsaved Blend Menu

### DIFF
--- a/arsenal-blender/__init__.py
+++ b/arsenal-blender/__init__.py
@@ -14,6 +14,7 @@ import stat
 from glob import glob
 
 import bpy
+from . import keymaps
 from . import operators
 from . import menus
 from . import panels
@@ -48,6 +49,7 @@ def register():
     for blender_class in blender_classes:
         bpy.utils.register_class(blender_class)
 
+    keymaps.register()
     operators.register()
     menus.register()
     panels.register()
@@ -58,6 +60,7 @@ def unregister():
     for blender_class in blender_classes:
         bpy.utils.unregister_class(blender_class)
 
+    keymaps.register()
     panels.unregister()
     menus.unregister()
     operators.unregister()

--- a/arsenal-blender/__init__.py
+++ b/arsenal-blender/__init__.py
@@ -15,6 +15,7 @@ from glob import glob
 
 import bpy
 from . import operators
+from . import menus
 from . import panels
 
 blender_classes = []
@@ -48,6 +49,7 @@ def register():
         bpy.utils.register_class(blender_class)
 
     operators.register()
+    menus.register()
     panels.register()
 
 def unregister():
@@ -57,5 +59,6 @@ def unregister():
         bpy.utils.unregister_class(blender_class)
 
     panels.unregister()
+    menus.unregister()
     operators.unregister()
 

--- a/arsenal-blender/keymaps.py
+++ b/arsenal-blender/keymaps.py
@@ -1,0 +1,19 @@
+import bpy
+
+from .operators import ArsenalRun
+
+key_maps = []
+
+def register():
+    wm = bpy.context.window_manager
+
+    # Add F5 shortcut for running the game
+    window_keymap = wm.keyconfigs.addon.keymaps.new(name='Window', space_type='EMPTY', region_type="WINDOW")
+    window_keymap.keymap_items.new(ArsenalRun.bl_idname, type='F5', value='PRESS')
+    key_maps.append(window_keymap)
+
+def unregister():
+    wm = bpy.context.window_manager
+    for key_map in key_maps:
+        wm.key_configs.addon.keymaps.remove(key_map)
+    del key_maps[:]

--- a/arsenal-blender/menus.py
+++ b/arsenal-blender/menus.py
@@ -1,0 +1,28 @@
+import bpy
+
+from . import arsenal
+
+blender_classes = []
+
+class SaveBeforeRunMenu(bpy.types.Menu):
+    """Menu displayed when attempting to run an unsaved blend"""
+    bl_label = "Save Blend Before Running Game"
+    bl_idname = "ARSENAL_MT_save_before_run"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.operator_context = 'INVOKE_AREA'
+
+        layout.operator("wm.save_mainfile")
+
+
+blender_classes.append(SaveBeforeRunMenu)
+
+def register():
+    for blender_class in blender_classes:
+        bpy.utils.register_class(blender_class)
+
+def unregister():
+    blender_classes.reverse()
+    for blender_class in blender_classes:
+        bpy.utils.unregister_class(blender_class)

--- a/arsenal-blender/operators.py
+++ b/arsenal-blender/operators.py
@@ -1,6 +1,7 @@
 import bpy
 
 from . import arsenal
+from .menus import SaveBeforeRunMenu
 
 blender_classes = []
 
@@ -10,6 +11,11 @@ class ArsenalRun(bpy.types.Operator):
     bl_label = "Run Game"
 
     def execute(self, context):
+        # Ensure blend has been saved before running game
+        if bpy.data.filepath == "":
+            bpy.ops.wm.call_menu(name=SaveBeforeRunMenu.bl_idname)
+            return {'FINISHED'}
+
         print("Running Arsenal Game")
         arsenal.operators.arsenal_run(context)
         return {'FINISHED'}


### PR DESCRIPTION
This PR adds a menu that pops up when trying to run the game when the blend is unsaved, and it adds a keyboard shortcut that allows you to run the game by pressing F5.