### PR TITLE
Fix coreaudio-sys Missing Dependency

### DIFF
--- a/arsenal_runtime/Cargo.toml
+++ b/arsenal_runtime/Cargo.toml
@@ -12,5 +12,5 @@ amethyst_gltf = "0.5"
 # Temporarily use a fork of coreaudio-sys that support cross-compiling from
 # linux.
 [replace.'coreaudio-sys:0.2.2']
-git = "https://github.com/zicklag/coreaudio-sys.git"
-branch = "feature/support-linux-cross-compiling"
+git = "https://github.com/RustAudio/coreaudio-sys.git"
+ref = "13a32d7"


### PR DESCRIPTION
@zicklag's fork of coreaudio-sys was deleted after the PR was merged so
we need to update the dependency to point to the merged commit.