### PR TITLE
Always Pull Rust Nightly

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,6 +44,7 @@ steps:
   # Build Python Extension for Linux
   - name: build-arsenal-blender-core
     image: rustlang/rust:nightly
+    pull: always
     depends_on:
       - clone
     commands:
@@ -136,6 +137,7 @@ steps:
   # Build Python Extension for Windows
   - name: build-arsenal-blender-core
     image: rustlang/rust:nightly
+    pull: always
     depends_on:
       - clone
     commands:
@@ -252,6 +254,7 @@ steps:
   # Build Python Extension for Mac
   - name: build-arsenal
     image: rustlang/rust:nightly
+    pull: always
     depends_on:
       - clone
     commands:


### PR DESCRIPTION
Add the "pull always" flag to the Rust nightly images to make sure that
we are always using the latest nightly.