### PR TITLE
Fix Typo in coreaudio-sys Dependency

### DIFF
--- a/arsenal_runtime/Cargo.lock
+++ b/arsenal_runtime/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "coreaudio-sys"
 version = "0.2.2"
-source = "git+https://github.com/zicklag/coreaudio-sys.git?branch=feature/support-linux-cross-compiling#e012a49a4532fabaf25964f07842bdb6d7cc2040"
+source = "git+https://github.com/RustAudio/coreaudio-sys.git?rev=13a32d7#13a32d718647b9e5be1defdef8197958cfda31fa"
 dependencies = [
  "bindgen 0.42.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -735,7 +735,7 @@ dependencies = [
 name = "coreaudio-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-replace = "coreaudio-sys 0.2.2 (git+https://github.com/zicklag/coreaudio-sys.git?branch=feature/support-linux-cross-compiling)"
+replace = "coreaudio-sys 0.2.2 (git+https://github.com/RustAudio/coreaudio-sys.git?rev=13a32d7)"
 
 [[package]]
 name = "cpal"
@@ -3004,7 +3004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
 "checksum core-text 13.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12684243b314c95600a2b49628fb775f91d97bbe18424522f665b77014f2a640"
 "checksum coreaudio-rs 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f229761965dad3e9b11081668a6ea00f1def7aa46062321b5ec245b834f6e491"
-"checksum coreaudio-sys 0.2.2 (git+https://github.com/zicklag/coreaudio-sys.git?branch=feature/support-linux-cross-compiling)" = "<none>"
+"checksum coreaudio-sys 0.2.2 (git+https://github.com/RustAudio/coreaudio-sys.git?rev=13a32d7)" = "<none>"
 "checksum coreaudio-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "78fdbabf58d5b1f461e31b94a571c109284f384cec619a3d96e66ec55b4de82b"
 "checksum cpal 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d58ae1ed6536b1b233f5e3aeb6997a046ddb4d05e3f61701b58a92eb254a829e"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"

--- a/arsenal_runtime/Cargo.toml
+++ b/arsenal_runtime/Cargo.toml
@@ -9,8 +9,8 @@ serde = "1.0"
 amethyst = "0.10"
 amethyst_gltf = "0.5"
 
-# Temporarily use a fork of coreaudio-sys that support cross-compiling from
-# linux.
+# Use the later version of coreaudio-sys that has support for cross-compiling
+# for Mac from Linux.
 [replace.'coreaudio-sys:0.2.2']
 git = "https://github.com/RustAudio/coreaudio-sys.git"
-ref = "13a32d7"
+rev = "13a32d7"


### PR DESCRIPTION
Use `rev` instead of `ref` for the git commit specifier for the replaced
coreaudio-sys dependency of the Arsenal Runtime.